### PR TITLE
Update contrib issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -24,8 +24,8 @@ Please note that only FINOS members can propose new projects. If you're interest
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
 ## Development Team
-### Leadership
-*Who will be the project's lead maintainer(s)? Provide full name, affiliation, work email address, and GitHub.com username.*
+### Maintainers
+*Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub.com username.*
 
 ### Confirmed contributors
 *If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*

--- a/.github/ISSUE_TEMPLATE/Special-Interest-Group-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Special-Interest-Group-Contribution.md
@@ -20,8 +20,8 @@ Please note that only FINOS members can propose new projects. If you're interest
 ## Existing Materials
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
-## SIG Leadership Team
-*List out the leadership team members, including full name, affiliation, work email address, and GitHub.com username*
+## SIG Maintainers
+*Who will be the [SIG maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub.com username.*
 
 # SIG Contribution and Onboarding process (v. 1.0, last updated on October 27, 2020)
 Below is the list of tasks that FINOS Team and the contribution author goes through in order to complete the FINOS SIG onboarding process. **Please do not edit these contents at contribution time!**

--- a/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
@@ -28,8 +28,8 @@ Please note that only FINOS members can propose new Standards projects. If you'r
 
 ## Development Team
 
-### Leadership
-*Who will be the project's lead maintainer(s)? Provide full name, affiliation, work email address, and GitHub.com username.*
+### Maintainers
+*Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub.com username.*
 
 ### Confirmed contributors
 *If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*


### PR DESCRIPTION
- updated references to project and SIG leadership in software project, standard project, and SIG contribution checklists
- added link to project maintainer cheatsheet