### PR TITLE
Streamlined Onboarding Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -106,7 +106,7 @@ _Describe the FINOS infrastructure you will need for this project, in addition t
 
 Below is the list of tasks that the **FINOS Team** go through in order to complete the FINOS approval process.  At this point, a FINOS Point-of-Contact (POC) should be assigned to this GitHub issue.
 
-**Please do not edit these contents when completing part 1, "describing the contribution" above. **
+**Please do not edit these contents when completing part 1, "describing the contribution" above.**
 
 ## Kick-off meeting
 - [ ] Set up kick-off meeting with project leads

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -36,21 +36,20 @@ This is a list of questions that need to be answered by the contributor in order
 ## Existing Materials
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
- - Project Repository
-   - [ ] GitHub / GitLab Repository _(delete as appropriate)_
+ - [ ] GitHub / GitLab Repository _(delete as appropriate)_
    - [ ] URL for the repository _(if it exists)_
    - [ ] Project Name _(enter here)_
    - [ ] @finos-admin has been given read-only permissions if private
-
+ - [ ] Is Continuous Integration used? _If so, which system is used?_
+ - [ ] Was the project ever released? _(yes / no)_ 
+   - [ ] If so, are releases public? _(yes / no)_ 
+   - [ ] And what's the latest released version?
+ - [ ] Existing Project Documentation _( URL / microsite / PDF etc detail here)_
  - [ ] Does the name have a registered trademark? _(yes / no)_
  - [ ] Is there a logo? _(yes / no)_
  - [ ] High-Level Presentation prepared for Technical Steering Committee _(~15 mins)_
- - [ ] Existing Project Documentation ( URL / microsite / PDF etc) _detail here_. 
- - [ ] Is Continuous Integration used? _If so, which system is used?_
- - [ ] Was the project ever released? If so, are releases public? And what's the latest released version?
- - [ ] Are meetings currently held for the project?
- - [ ] Are meeting minutes, agenda and attendance tracked?
- - [ ] Does the name have a registered trademark?
+ - [ ] Are meetings currently held for the project? _(yes / no + details)_
+ - [ ] Are meeting minutes, agenda and attendance tracked? _(yes / no + details)_
 
 ## Development Team
 
@@ -76,22 +75,27 @@ This is a list of questions that need to be answered by the contributor in order
 *Describe the contributor profile (background, position, organization) you would like to get contributions from*
 
 ## Infrastructure needs
-*Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure*
+*Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure.  Remove items if not required. *
 
-- [ ] Recurring meetings
-- [ ] Mailing list
 - [ ] A project on the [Legend Studio shared instance](https://community.finos.org/docs/platforms/legend-studio-shared)
-- [ ] Other (please explain):
+- [ ] Other _(please explain)_
 
 ## Project Communication Channel(s)
+*Remove items if not required*
+
 - [ ] Contributor to ask maintainers which communications channels they'd like to use:
 - Asynchronous
-  - [ ] GitHub Issues (_public_)
-  - [ ] GitHub Discussions (_public_)
-  - [ ] GitHub Team Discussions (_public_ and _private_ **FINOS CLAs Required**)
+  - [ ] GitHub Issues _(public)_
+  - [ ] GitHub Discussions _(public)_
+  - [ ] GitHub Team Discussions _(consisting of the above described contributors)_
+    - [ ] Public
+    - [ ] Private
   - [ ] Mailing-list (groups.io)
+  - [ ] FINOS Slack Channel (consisting of the above described contributors)
+    - [ ] General _(public Slack)_ 
+    - [ ] Leadership _(private Slack)_
 - Synchronous
-  - [ ] FINOS Slack Channel (general _public Slack_ / leadership _private Slack_)
+  - [ ] Recurring meetings
 
 # Finally...
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -75,7 +75,7 @@ This is a list of questions that need to be answered by the contributor in order
 *Describe the contributor profile (background, position, organization) you would like to get contributions from.*
 
 ## Infrastructure needs
-*Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure.  Remove items if not required. *
+_Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure.  Remove items if not required._
 
 - [ ] A project on the [Legend Studio shared instance](https://community.finos.org/docs/platforms/legend-studio-shared)
 - [ ] Other _(please explain)_

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -152,7 +152,7 @@ Before the FINOS team can onboard your project, there are a few housekeeping tha
  - [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws. _(POC to validate with FINOS Legal team if anything important is raised)_
 
 ## Coding Standards 
-- [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries.  _Enable GitHub actions from [Security Scanning](https://github.com/maoo/security-scanning) to ensure this._
+- [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries.  _Enable GitHub actions from [Security Scanning](https://github.com/finos/security-scanning) to ensure this._
 - [ ] The codebase doesn’t have any unfriendly licenses across direct and transitive libraries
 - [ ] (optional - if a build system is provided) The build process runs successfully
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -158,6 +158,7 @@ Before the FINOS team can onboard your project, there are a few housekeeping tha
 ## Logo / Copyright
  - [ ] Initiate transfer of copyrights to FINOS. 
  - [ ] Request logo design from `help@finos.org` _(if needed)_
+ - [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws. _(POC to validate with FINOS Legal team if anything important is raised)_
 
 ## Coding Standards 
 - [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries.  _Enable GitHub actions from [Security Scanning](https://github.com/maoo/security-scanning) to ensure this._
@@ -166,7 +167,6 @@ Before the FINOS team can onboard your project, there are a few housekeeping tha
 
 ## FINOS Project Standards
 - [ ] [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
-- [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws (to be validated with FINOS Legal team)
 - [ ] Apply project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
     - [ ] README.md file contains the sections in the [README Template](https://github.com/finos/software-project-blueprint/blob/main/README.template.md)
     - [ ] Project badge in README

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -12,10 +12,10 @@ Please note that only FINOS members can propose new projects. If you're interest
 
 Completing an onboarding of a project into FINOS requires following these 4 main steps:  
 
-1.  Describing the Contribution _led by contributor_
-2.  FINOS Approval _led by FINOS Point of Contact (POC)_
-3.  Preparing for Onboarding _led by contributor_
-4.  Onboarding _completed by FINOS Infra_
+1.  **Describing the Contribution** _led by contributor_
+2.  **FINOS Approval** _led by FINOS Point of Contact (POC)_
+3.  **Preparing for Onboarding** _led by contributor_
+4.  **Onboarding** _completed by FINOS Infra_
 
 # 1. Describing The Contribution
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -3,7 +3,6 @@ name: "\U0001F58ASoftware Project Contribution and Onboarding"
 about: To Contribute a Software Project to FINOS
 title: Software Project Contribution and Onboarding
 labels: contribution
-assignees: mcleo-d
 
 ---
 Please note that only FINOS members can propose new projects. If you're interested in membership, see https://www.finos.org/membership-benefits#become-a-member.
@@ -13,13 +12,14 @@ Please note that only FINOS members can propose new projects. If you're interest
 
 Completing an onboarding of a project into FINOS requires following these 4 main steps:  
 
-1.  [Describing the Contribution](#describing-the-contribution)
-2.  [Approval]()
-3.  [Preparing for Contribution]()
-4.  [Onboarding]()
-
+1.  Describing the Contribution _performed by contributor_
+2.  FINOS Approval _performed by FINOS_
+3.  Preparing for Contribution _performed by contributor_
+4.  Onboarding _completed by FINOS_
 
 # Describing The Contribution
+
+This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
 
 ## Business Problem
 *Describe the business problem the contribution solves*
@@ -36,30 +36,52 @@ Completing an onboarding of a project into FINOS requires following these 4 main
 ## Existing Materials
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
+ - [ ] GitHub / GitLab Repository _(delete as appropriate)_
+ - [ ] @finos-admin has been given read-only permissions if private
+ - [ ] High-Level Presentation prepared for Technical Steering Committee _(~15 mins)_
+ - [ ] Existing Project Documentation ( URL / microsite / PDF etc) _detail here_. 
+
 ## Development Team
 ### Maintainers
-*Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub.com username.*
+*Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub / GitLab username.*
+
+|Name                        |Work Email Address.                             |Github / GitLab username|
+|----------------------------|------------------------------------------------|------------------------|
+|John Example                |john@example.com                                |@johnexampleabc         |
+|Jane Example                |jane@example.com                                |@janeexamplexyz         |
+
 
 ### Confirmed contributors
 *If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*
+
+|Name                        |Work Email Address.                             |Github / GitLab username|
+|----------------------------|------------------------------------------------|------------------------|
+|Contributor1 Example        |con1@example.com                                |@con1xampleabc          |
+|Contributor2 Example        |con2@example.com                                |@con2examplexyz         |
+
 
 ### Target Contributors
 *Describe the contributor profile (background, position, organization) you would like to get contributions from*
 
 ## Infrastructure needs
 *Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure*
+
 - [ ] Recurring meetings
 - [ ] Mailing list
 - [ ] A project on the [Legend Studio shared instance](https://community.finos.org/docs/platforms/legend-studio-shared)
 - [ ] Other (please explain):
 
-# What's next?
-Upon submission of this project proposal, the FINOS team will get in touch with you to discuss next steps. 
+# Finally...
 
------
+ - [ ] All the above sections are completed / ticked
+ - [ ] Notify help@finos.org that you have completed the _describing the contribution_ section. 
 
-# Contribution process (v. 1.1, last updated on December 20, 2021)
-Below is the list of tasks that FINOS Team and the contribution author go through in order to complete the FINOS contribution process.
+
+
+
+# FINOS Approval
+
+Below is the list of tasks that FINOS Team and the contribution author go through in order to complete the FINOS approval process.
 **Please do not edit these contents at contribution time!**
 
 ## Kick-off meeting

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -12,10 +12,10 @@ Please note that only FINOS members can propose new projects. If you're interest
 
 Completing an onboarding of a project into FINOS requires following these 4 main steps:  
 
-1.  Describing the Contribution _performed by contributor_
-2.  FINOS Approval _performed by FINOS_
-3.  Preparing for Onboarding _performed by contributor_
-4.  Onboarding _completed by FINOS_
+1.  Describing the Contribution _led by contributor_
+2.  FINOS Approval _led by FINOS_
+3.  Preparing for Onboarding _led by contributor_
+4.  Onboarding _completed by FINOS Infra_
 
 # 1. Describing The Contribution
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -13,7 +13,7 @@ Please note that only FINOS members can propose new projects. If you're interest
 Completing an onboarding of a project into FINOS requires following these 4 main steps:  
 
 1.  Describing the Contribution _led by contributor_
-2.  FINOS Approval _led by FINOS_
+2.  FINOS Approval _led by FINOS Point of Contact (POC)_
 3.  Preparing for Onboarding _led by contributor_
 4.  Onboarding _completed by FINOS Infra_
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -8,6 +8,19 @@ assignees: mcleo-d
 ---
 Please note that only FINOS members can propose new projects. If you're interested in membership, see https://www.finos.org/membership-benefits#become-a-member.
 
+
+# Onboarding Process
+
+Completing an onboarding of a project into FINOS requires following these 4 main steps:  
+
+1.  [Describing the Contribution](#describing-the-contribution)
+2.  [Approval]()
+3.  [Preparing for Contribution]()
+4.  [Onboarding]()
+
+
+# Describing The Contribution
+
 ## Business Problem
 *Describe the business problem the contribution solves*
  

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -56,19 +56,19 @@ This is a list of questions that need to be answered by the contributor in order
 ### Maintainers
 *Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub / GitLab username.*
 
-|Name                        |Work Email Address.                             |Github / GitLab username|
-|----------------------------|------------------------------------------------|------------------------|
-|John Example                |john@example.com                                |@johnexampleabc         |
-|Jane Example                |jane@example.com                                |@janeexamplexyz         |
+|Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
+|----------------------------|-------------------------|-------------------------------|--------------------------------------|
+|John Example                |Example LTD              |john@example.com               |@johnexampleabc                       |
+|Jane Example                |Example LTD              |jane@example.com               |@janeexamplexyz                       |
 
 
 ### Confirmed contributors
 *If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*
 
-|Name                        |Work Email Address.                             |Github / GitLab username|
-|----------------------------|------------------------------------------------|------------------------|
-|Contributor1 Example        |con1@example.com                                |@con1xampleabc          |
-|Contributor2 Example        |con2@example.com                                |@con2examplexyz         |
+|Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
+|----------------------------|-------------------------|-------------------------------|--------------------------------------|
+|Contributor1 Example        |Example LTD              |con1@example.com               |@con1xampleabc                        |
+|Contributor2 Example        |Example LTD              |con2@example.com               |@con2examplexyz                       |
 
 
 ### Target Contributors

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -10,12 +10,13 @@ Please note that only FINOS members can propose new projects. If you're interest
 
 # Onboarding Process
 
-Completing an onboarding of a project into FINOS requires following these 4 main steps:  
+Completing an onboarding of a project into FINOS requires following these 5 main steps:  
 
 1.  **Describing the Contribution** _led by contributor_
 2.  **FINOS Approval** _led by FINOS Point of Contact (POC)_
 3.  **Preparing for Onboarding** _led by contributor_
 4.  **Onboarding** _completed by FINOS Infra_
+5.  **Announcement** _led by FINOS Point of Contact (POC)_
 
 # 1. Describing The Contribution
 
@@ -107,6 +108,9 @@ Below is the list of tasks that the **FINOS Team** go through in order to comple
 
 **Please do not edit these contents when completing part 1, "describing the contribution" above.**
 
+## Record The Contribution
+- [ ] Record Contribution as "Exploratory" by sending an email to **LF Legal Representative** with a summary of the **Business Problem** and **Proposed Solution** (above) of the project.
+
 ## Kick-off meeting
 - [ ] Set up kick-off meeting with project leads
 - [ ] Run kick-off meeting
@@ -138,6 +142,7 @@ Below is the list of tasks that the **FINOS Team** go through in order to comple
 - [ ] TSC to invite contributors to present their project
 - [ ] FINOS TSC approves/rejects the contribution
 - [ ] (optional) If additional socialization is required, the Executive Director may bring projects to the FINOS Governing Board
+- [ ] Update the contribution status to "Engaged" by sending another email to **LF Legal Representative** with the name of the project and its new status.
 
 ## TSC Findings / Report
 *TSC to enter findings summary here.*
@@ -230,6 +235,10 @@ This is performed by FINOS Infra once the three previous stages are complete, wi
 - [ ] (optional) Enable meeting attendance tracking
 - [ ] (optional) Onboard into legend.finos.org/studio
 
-## Announcement (Lead: FINOS Contrib POC)
+# 5. Announcement 
+
+(Lead: FINOS Contrib POC)
+
+- [ ] Update the contribution status to "Active" by sending another email to **LF Legal Representative** with the name of the project and its new status.
 - [ ] Lead maintainer works with FINOS marketing to send out announcement to announce@finos.org , checkout announcement template at the [Contribution page](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements)
-- [ ] Notify FINOS Contrib POC and FINOS marketing (@grizzwolf + finos-marketing internal Slack channel)
+- [ ] Notify FINOS marketing (@grizzwolf + finos-marketing internal Slack channel)

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -92,8 +92,8 @@ _Describe the FINOS infrastructure you will need for this project, in addition t
     - [ ] Private
   - [ ] Mailing-list (groups.io)
   - [ ] FINOS Slack Channel (consisting of the above described contributors)
-    - [ ] General _(public Slack)_ 
-    - [ ] Leadership _(private Slack)_
+    - [ ] General (public) _(supply channel name)_ 
+    - [ ] Leadership (private) _(supply channel name)_
 - Synchronous
   - [ ] Recurring meetings
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -21,15 +21,6 @@ Completing an onboarding of a project into FINOS requires following these 4 main
 
 This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
 
-## Understanding FINOS Onboarding Requirements
-
-As a project onboarding into FINOS, you will need to familiarize yourself and your contributor team with the following materials:
-
-  - [ ] [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
-  - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
-  - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
-  - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
-
 ## Business Problem
 *Describe the business problem the contribution solves*
  
@@ -83,12 +74,6 @@ As a project onboarding into FINOS, you will need to familiarize yourself and yo
 ### Target Contributors
 *Describe the contributor profile (background, position, organization) you would like to get contributions from.*
 
-## Infrastructure needs
-_Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure.  Remove items if not required._
-
-- [ ] A project on the [Legend Studio shared instance](https://community.finos.org/docs/platforms/legend-studio-shared)
-- [ ] Other _(please explain)_
-
 ## Project Communication Channel(s)
 *Remove items if not required*
 
@@ -106,9 +91,14 @@ _Describe the FINOS infrastructure you will need for this project, in addition t
 - Synchronous
   - [ ] Recurring meetings
 
-## Finally...
+## Understanding FINOS Onboarding Requirements
 
- - [ ] All the above sections are completed / ticked
+As a project onboarding into FINOS, you will need to familiarize yourself and your contributor team with the following materials:
+
+ - [ ] [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
+ - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
+ - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
+ - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
  - [ ] Notify help@finos.org that you have completed the _describing the contribution_ section. 
 
 # 2. FINOS Approval
@@ -155,8 +145,8 @@ Below is the list of tasks that the **FINOS Team** go through in order to comple
 
 Before the FINOS team can onboard your project, there are a few housekeeping that need to be taken care of.  These must be completed by the contributor, with help if required from the POC or FINOS Infra.   
 
-## Logo / Copyright
- - [ ] Initiate transfer of copyrights to FINOS. 
+## Logo / Trademarks
+ - [ ] Initiate transfer of trademarks to FINOS _(request help from help@finos.org / LF Legal if needed)_
  - [ ] Request logo design from `help@finos.org` _(if needed)_
  - [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws. _(POC to validate with FINOS Legal team if anything important is raised)_
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -14,10 +14,10 @@ Completing an onboarding of a project into FINOS requires following these 4 main
 
 1.  Describing the Contribution _performed by contributor_
 2.  FINOS Approval _performed by FINOS_
-3.  Preparing for Contribution _performed by contributor_
+3.  Preparing for Onboarding _performed by contributor_
 4.  Onboarding _completed by FINOS_
 
-# Describing The Contribution
+# 1. Describing The Contribution
 
 This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
 
@@ -36,12 +36,24 @@ This is a list of questions that need to be answered by the contributor in order
 ## Existing Materials
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
- - [ ] GitHub / GitLab Repository _(delete as appropriate)_
- - [ ] @finos-admin has been given read-only permissions if private
+ - Project Repository
+   - [ ] GitHub / GitLab Repository _(delete as appropriate)_
+   - [ ] URL for the repository _(if it exists)_
+   - [ ] Project Name _(enter here)_
+   - [ ] @finos-admin has been given read-only permissions if private
+
+ - [ ] Does the name have a registered trademark? _(yes / no)_
+ - [ ] Is there a logo? _(yes / no)_
  - [ ] High-Level Presentation prepared for Technical Steering Committee _(~15 mins)_
  - [ ] Existing Project Documentation ( URL / microsite / PDF etc) _detail here_. 
+ - [ ] Is Continuous Integration used? _If so, which system is used?_
+ - [ ] Was the project ever released? If so, are releases public? And what's the latest released version?
+ - [ ] Are meetings currently held for the project?
+ - [ ] Are meeting minutes, agenda and attendance tracked?
+ - [ ] Does the name have a registered trademark?
 
 ## Development Team
+
 ### Maintainers
 *Who will be the [project maintainer(s)](https://odp.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub / GitLab username.*
 
@@ -71,15 +83,22 @@ This is a list of questions that need to be answered by the contributor in order
 - [ ] A project on the [Legend Studio shared instance](https://community.finos.org/docs/platforms/legend-studio-shared)
 - [ ] Other (please explain):
 
+## Project Communication Channel(s)
+- [ ] Contributor to ask maintainers which communications channels they'd like to use:
+- Asynchronous
+  - [ ] GitHub Issues (_public_)
+  - [ ] GitHub Discussions (_public_)
+  - [ ] GitHub Team Discussions (_public_ and _private_ **FINOS CLAs Required**)
+  - [ ] Mailing-list (groups.io)
+- Synchronous
+  - [ ] FINOS Slack Channel (general _public Slack_ / leadership _private Slack_)
+
 # Finally...
 
  - [ ] All the above sections are completed / ticked
  - [ ] Notify help@finos.org that you have completed the _describing the contribution_ section. 
 
-
-
-
-# FINOS Approval
+# 2. FINOS Approval
 
 Below is the list of tasks that FINOS Team and the contribution author go through in order to complete the FINOS approval process.
 **Please do not edit these contents at contribution time!**
@@ -91,7 +110,7 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
     - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
     - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
     - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
-    - [ ] Walk through the checklist, answer questsion and remove items that don't apply
+    - [ ] Walk through the checklist, answer questions and remove items that don't apply
     - [ ] Write and send contribution proposal announcement (optional - see below)
 
 ## FINOS Contrib POC
@@ -111,12 +130,34 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
    Thanks a lot,
    ```
 
+## Technical Steering Committee Approval
+- [ ] Prioritise this issue on the TSC Backlog
+- [ ] Assign this issue to the TSC
+- [ ] TSC to invite contributors to present their project
+- [ ] FINOS TSC approves the contribution
+- [ ] (optional) If additional socialization is required, the Executive Director may bring projects to the FINOS Governing Board
+
+## TSC Findings / Report
+*TSC to enter findings summary here.*
+
+# 3. Preparing For Onboarding
+
+Before the FINOS team can onboard your project, there are a few housekeeping that need to be taken care of.
+
+## Code validation 
+- [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries
+- [ ] The codebase doesn’t have any unfriendly licenses across direct and transitive libraries
+- [ ] (optional - if a build system is provided) The build process runs successfully
+- [ ] [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
+- [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws (to be validated with FINOS Legal team)
+- [ ] Apply project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
+    - [ ] Ensure that the proper project governance is in the CONTRIBUTING.md file
+- [ ] [All incubating criteria](https://community.finos.org/docs/governance/Software-Projects/stages/incubating) are checked and documented below
+
 ## Identify project meta (Lead: FINOS Contrib POC, Support: FINOS Marketing)
-- Project main coordinates
-    - [ ] Project Name
-    - [ ] Project Slug
-    - [ ] Does the name have a registered trademark?
-    - [ ] Request logo design (if needed)
+- [ ] Project Slug _(a short name that forms part of the url.  E.g. `test` at the end of https://github.com/finos/test)_
+- [ ] Does the name have a registered trademark?
+- [ ] Request logo design (if needed)
 - [ ] Category and sub-category (for [FINOS Landscape](https://landscape.finos.org/))
 - [ ] Is there existing code? If so, is it public? If not, can you grant read access to user github.com/finos-admin ?
 - [ ] Was the project ever released? If so, are releases public? And what's the latest released version?
@@ -164,10 +205,6 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
     - [ ] Ensure that the proper project governance is in the CONTRIBUTING.md file
 - [ ] [All incubating criteria](https://community.finos.org/docs/governance/Software-Projects/stages/incubating) are checked and documented below
 
-## Approval (Lead: FINOS TSC)
-- [ ] FINOS TSC approves the contribution
-- [ ] (optional) If additional socialization is required, the Executive Director may bring projects to the FINOS Governing Board
-
 ## Code transfer (Lead: FINOS Infra)
 - [ ] Backup (even with screenshot) GitHub permissions of the repository to transfer
 - [ ] Check GitHub repository transfer requirements:
@@ -186,6 +223,17 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
 - [ ] Invite GitHub usernames to GitHub FINOS Org
 - [ ] Create `<project-name>-maintainers` GitHub team and invite users
 - [ ] Configure `finos-admins` (`Maintain` role) and `finos-staff` (`Triage` role) team permissions
+
+
+## Communication Channels
+- [ ] Create the identified communication channels during infra set up
+    - [ ] Create mailing-list on lists.finos.org (optional)
+        - [ ] Enable Hubspot Sync for all project mailing lists created
+        - [ ] Aggregate mailing lists to community@finos.org
+        - [ ] Update marketing lists
+          - Add new list to the included "Email List" part of the filter
+          - Add new list to the excluded "Email" part of the filter
+- [ ] Link communication channels linked front and center in the project README.md
 
 
 ## Infra setup (Lead: FINOS Infra)

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -72,7 +72,7 @@ This is a list of questions that need to be answered by the contributor in order
 
 
 ### Target Contributors
-*Describe the contributor profile (background, position, organization) you would like to get contributions from*
+*Describe the contributor profile (background, position, organization) you would like to get contributions from.*
 
 ## Infrastructure needs
 *Describe the FINOS infrastructure you will need for this project, in addition to a GitHub repository. The FINOS team will connect with you before setting up any of this infrastructure.  Remove items if not required. *

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -97,15 +97,16 @@ This is a list of questions that need to be answered by the contributor in order
 - Synchronous
   - [ ] Recurring meetings
 
-# Finally...
+## Finally...
 
  - [ ] All the above sections are completed / ticked
  - [ ] Notify help@finos.org that you have completed the _describing the contribution_ section. 
 
 # 2. FINOS Approval
 
-Below is the list of tasks that FINOS Team and the contribution author go through in order to complete the FINOS approval process.
-**Please do not edit these contents at contribution time!**
+Below is the list of tasks that the **FINOS Team** go through in order to complete the FINOS approval process.  At this point, a FINOS Point-of-Contact (POC) should be assigned to this GitHub issue.
+
+**Please do not edit these contents when completing part 1, "describing the contribution" above. **
 
 ## Kick-off meeting
 - [ ] Set up kick-off meeting with project leads
@@ -114,7 +115,7 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
     - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
     - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
     - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
-    - [ ] Walk through the checklist, answer questions and remove items that don't apply
+    - [ ] Walk through the checklist in part 1, ensure all the questions are answered and remove items that don't apply
     - [ ] Write and send contribution proposal announcement (optional - see below)
 
 ## FINOS Contrib POC
@@ -135,10 +136,11 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
    ```
 
 ## Technical Steering Committee Approval
-- [ ] Prioritise this issue on the TSC Backlog
-- [ ] Assign this issue to the TSC
+
+- [ ] Prioritise this issue on the [TSC Backlog](https://github.com/orgs/finos/projects/39)
+- [ ] Assign this issue to @colineberhardt
 - [ ] TSC to invite contributors to present their project
-- [ ] FINOS TSC approves the contribution
+- [ ] FINOS TSC approves/rejects the contribution
 - [ ] (optional) If additional socialization is required, the Executive Director may bring projects to the FINOS Governing Board
 
 ## TSC Findings / Report
@@ -146,101 +148,75 @@ Below is the list of tasks that FINOS Team and the contribution author go throug
 
 # 3. Preparing For Onboarding
 
-Before the FINOS team can onboard your project, there are a few housekeeping that need to be taken care of.
+Before the FINOS team can onboard your project, there are a few housekeeping that need to be taken care of.  These must be completed by the contributor, with help if required from the POC or FINOS Infra.   
 
-## Code validation 
-- [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries
+## Logo / Copyright
+ - [ ] Initiate transfer of copyrights to FINOS. 
+ - [ ] Request logo design from `help@finos.org` _(if needed)_
+
+## Coding Standards 
+- [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries.  _Enable GitHub actions from [Security Scanning](https://github.com/maoo/security-scanning) to ensure this._
 - [ ] The codebase doesn’t have any unfriendly licenses across direct and transitive libraries
 - [ ] (optional - if a build system is provided) The build process runs successfully
+
+## FINOS Project Standards
 - [ ] [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
 - [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws (to be validated with FINOS Legal team)
 - [ ] Apply project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
+    - [ ] README.md file contains the sections in the [README Template](https://github.com/finos/software-project-blueprint/blob/main/README.template.md)
+    - [ ] Project badge in README
+    - [ ] License in README
+    - [ ] Contributing in README
+    - [ ] `CONTRIBUTING.md`
+    - [ ] `LICENSE` (replace `{}` placeholders)
     - [ ] Ensure that the proper project governance is in the CONTRIBUTING.md file
 - [ ] [All incubating criteria](https://community.finos.org/docs/governance/Software-Projects/stages/incubating) are checked and documented below
 
-## Identify project meta (Lead: FINOS Contrib POC, Support: FINOS Marketing)
-- [ ] Project Slug _(a short name that forms part of the url.  E.g. `test` at the end of https://github.com/finos/test)_
-- [ ] Does the name have a registered trademark?
-- [ ] Request logo design (if needed)
-- [ ] Category and sub-category (for [FINOS Landscape](https://landscape.finos.org/))
-- [ ] Is there existing code? If so, is it public? If not, can you grant read access to user github.com/finos-admin ?
-- [ ] Was the project ever released? If so, are releases public? And what's the latest released version?
-- [ ] Team composition: lead maintainer and other maintainers
-- [ ] Are meetings currently held for the project?
-- [ ] Are meeting minutes, agenda and attendance tracked?
-- [ ] Is Continuous Integration used? If so, which system is used?
-- [ ] Is there an existing Documentation website? If not, would you like to have one?
+_Add documentation here_
 
-## Maintainers, contributors and CLAs (Lead: FINOS Contrib POC, Support: FINOS infra)
-- [ ] For each maintainer identified in the previous step, collect: the following info:
-  - Fullname
-  - GitHub username
-  - Corporate email address
+# 4.  FINOS Onboarding
+
+This is performed by FINOS Infra once the three previous stages are complete, with support from the contributor and the FINOS POC.
+
+## Maintainers, Contributors and CLAs 
 - [ ] Identify other existing contributors (assuming there's a contribution history (eg Git history)
 - [ ] Check if maintainers and other contributors are all covered by FINOS CLA
 - [ ] Engage with FINOS Legal team to figure out what’s needed to cover all maintainers and contributors with FINOS CLA
 - [ ] Reach out to contributors and employers to coordinate CLA signatures
 
-## Project Communication Channel(s)
-- [ ] Ask maintainers which communications channels they'd like to use
-- Asynchronous
-  - [ ] GitHub Issues (_public_)
-  - [ ] GitHub Discussions (_public_)
-  - [ ] GitHub Team Discussions (_public_ and _private_ **FINOS CLAs Required**)
-  - [ ] Mailing-list (groups.io)
-- Synchronous
-  - [ ] FINOS Slack Channel (general _public Slack_ / leadership _private Slack_)
-- [ ] Create the identified communication channels during infra set up
-    - [ ] Create mailing-list on lists.finos.org (optional)
-        - [ ] Enable Hubspot Sync for all project mailing lists created
-        - [ ] Aggregate mailing lists to community@finos.org
-        - [ ] Update marketing lists
-          - Add new list to the included "Email List" part of the filter
-          - Add new list to the excluded "Email" part of the filter
-- [ ] Link communication channels linked front and center in the project README.md
-
-## Code validation (only if code is contributed) (Lead: FINOS Infra)
+## Validation (only if code is contributed) 
 - [ ] The codebase doesn’t have HIGH or CRITICAL CVEs across direct and transitive libraries
 - [ ] The codebase doesn’t have any unfriendly licenses across direct and transitive libraries
 - [ ] (optional - if a build system is provided) The build process runs successfully
 - [ ] [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
 - [ ] The codebase doesn’t include any patent or copyright that conflicts with FINOS Governance and bylaws (to be validated with FINOS Legal team)
-- [ ] Apply project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
-    - [ ] Ensure that the proper project governance is in the CONTRIBUTING.md file
-- [ ] [All incubating criteria](https://community.finos.org/docs/governance/Software-Projects/stages/incubating) are checked and documented below
+- [ ] Check project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
+- [ ] [All incubating criteria](https://community.finos.org/docs/governance/Software-Projects/stages/incubating) are met (review documentation provided above)
 
-## Code transfer (Lead: FINOS Infra)
+## Code transfer 
 - [ ] Backup (even with screenshot) GitHub permissions of the repository to transfer
 - [ ] Check GitHub repository transfer requirements:
   - [ ] [finos-admin](http://github.com/finos-admin) has `Admin` to all repositories to transfer
   - [ ] [finos-admin](http://github.com/finos-admin) ia allowed to transfer repositories out of the org
   - [ ] if the repository is owned by a user (and not an org), the user must be able to transfer the repository to [finos-admin](http://github.com/finos-admin)
-- [ ] Review FINOS [project blueprint contents](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
-    - [ ] Project title/description in README
-    - [ ] Project badge in README
-    - [ ] License in README
-    - [ ] Contributing in README
-    - [ ] `CONTRIBUTING.md`
-    - [ ] `LICENSE` (look for `{}` placeholders)
 - [ ] Check protection settings and disable after transfer if necessary
 - [ ] Transfer all code assets as GitHub repositories under github.com/finos
 - [ ] Invite GitHub usernames to GitHub FINOS Org
 - [ ] Create `<project-name>-maintainers` GitHub team and invite users
 - [ ] Configure `finos-admins` (`Maintain` role) and `finos-staff` (`Triage` role) team permissions
 
-
-## Communication Channels
+## Project Communication Channel(s)
 - [ ] Create the identified communication channels during infra set up
-    - [ ] Create mailing-list on lists.finos.org (optional)
-        - [ ] Enable Hubspot Sync for all project mailing lists created
-        - [ ] Aggregate mailing lists to community@finos.org
-        - [ ] Update marketing lists
-          - Add new list to the included "Email List" part of the filter
-          - Add new list to the excluded "Email" part of the filter
-- [ ] Link communication channels linked front and center in the project README.md
+- [ ] Create mailing-list on lists.finos.org (if requested)
+    - [ ] Enable Hubspot Sync for all project mailing lists created
+    - [ ] Aggregate mailing lists to community@finos.org
+    - [ ] Update marketing lists
+      - Add new list to the included "Email List" part of the filter
+      - Add new list to the excluded "Email" part of the filter
+- [ ] Create Slack channels if requested.
+- [ ] Link communication channels linked front-and-center in the project README.md
 
-
-## Infra setup (Lead: FINOS Infra)
+## Infra setup 
 - [ ] Enable EasyCLA
 - [ ] Add project to metadata
 - [ ] Add identities, orgs and affiliations to metadata (deprecated by EasyCLA)
@@ -254,7 +230,7 @@ Before the FINOS team can onboard your project, there are a few housekeeping tha
 - [ ] Add project maintainers GitHub usernames to the [project-maintainers Team](https://github.com/orgs/finos/teams/project-maintainers/members)
 - [ ] Onboard project on LF systems ([SFDC](https://jira.linuxfoundation.org/browse/SS), Insights, EasyCLA, Groups.io)
 - [ ] (best effort) Update release coordinates and code namespace to include `finos`
-- [ ] Enable security vulnerabilities scanning
+- [ ] Check security vulnerabilities scanning is in place
 - [ ] (optional) Enable meeting attendance tracking
 - [ ] (optional) Onboard into legend.finos.org/studio
 

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -21,6 +21,15 @@ Completing an onboarding of a project into FINOS requires following these 4 main
 
 This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
 
+## Understanding FINOS Onboarding Requirements
+
+As a project onboarding into FINOS, you will need to familiarize yourself and your contributor team with the following materials:
+
+  - [ ] [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
+  - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
+  - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
+  - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
+
 ## Business Problem
 *Describe the business problem the contribution solves*
  
@@ -111,12 +120,8 @@ Below is the list of tasks that the **FINOS Team** go through in order to comple
 ## Kick-off meeting
 - [ ] Set up kick-off meeting with project leads
 - [ ] Run kick-off meeting
-    - [ ] [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
-    - [ ] [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
-    - [ ] [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
-    - [ ] [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
-    - [ ] Walk through the checklist in part 1, ensure all the questions are answered and remove items that don't apply
-    - [ ] Write and send contribution proposal announcement (optional - see below)
+  - [ ] Walk through the checklist in part 1, ensure all the questions are answered and remove items that don't apply
+  - [ ] Write and send contribution proposal announcement (optional - see below)
 
 ## FINOS Contrib POC
 - [ ] Identify and Assign FINOS Project Coordinator

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -165,7 +165,8 @@ Before the FINOS team can onboard your project, there are a few housekeeping tha
 - [ ] [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
 - [ ] Apply project blueprint contents - see [ODP docs](https://community.finos.org/docs/collaboration-infrastructure#finos-project-blueprint)
     - [ ] README.md file contains the sections in the [README Template](https://github.com/finos/software-project-blueprint/blob/main/README.template.md)
-    - [ ] Project badge in README
+    - [ ] Project FINOS badge in README (incubating)
+    - [ ] [OpenSSF Passing Badge](https://bestpractices.coreinfrastructure.org/en)
     - [ ] License in README
     - [ ] Contributing in README
     - [ ] `CONTRIBUTING.md`

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -134,6 +134,7 @@ Below is the list of tasks that the **FINOS Team** go through in order to comple
 
 - [ ] Prioritise this issue on the [TSC Backlog](https://github.com/orgs/finos/projects/39)
 - [ ] Assign this issue to @colineberhardt
+- [ ] Add the `ready-for-tsc` label
 - [ ] TSC to invite contributors to present their project
 - [ ] FINOS TSC approves/rejects the contribution
 - [ ] (optional) If additional socialization is required, the Executive Director may bring projects to the FINOS Governing Board


### PR DESCRIPTION
As discussed in the meeting last week, I've re-arranged the onboarding template to reduce the number of hand-offs.  There are four stages (described at the top), each with a different owner.    I've preserved everything from the original template, but tried to put the contributor in the driving seat for answering as many of the questions as possible.  

Hopefully, this should mean that the FINOS Point-Of-Contact only needs to get involved for a short period of time in step 2, to get the project through the technical steering committee, and that FINOS Infra only needs to get involved at the very end, and can complete the onboarding without involving the original contributor at all, since they've already provided all the information required to complete the onboarding.  

Hopefully this makes sense, happy to do a walkthrough if that helps.